### PR TITLE
Allow Markdown TOC to be rendered

### DIFF
--- a/bleach_whitelist/bleach_whitelist.py
+++ b/bleach_whitelist/bleach_whitelist.py
@@ -61,6 +61,7 @@ markdown_tags = [
 ]
 
 markdown_attrs = {
+    "*": ["id"],
     "img": ["src", "alt", "title"],
     "a": ["href", "alt", "title"],
 }


### PR DESCRIPTION
Python's Markdown package supports Table of Content generation by adding "id" attributes HTML elements. I've whitelisted the "id" attribute for Markdown rendering, so that linking in TOC can be properly supported. This change shouldn't be affecting the effectiveness of HTML sanitizing, as Bleach is still filtering "harmful" elements.